### PR TITLE
Update to make more easily compilable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,22 @@
 			<id>repo</id>
 			<url>https://repo.glaremasters.me/repository/public/</url>
 		</repository>
+		<!-- Bundabrg's Repo -->
+		<repository>
+			<id>bundabrg-repo</id>
+			<url>https://repo.worldguard.com.au/repository/maven-public</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<!-- Jitpack -->
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -47,6 +63,14 @@
             <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.12</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- Used for skull -->
         <dependency>
@@ -107,16 +131,15 @@
 		<dependency>
 			<groupId>com.gamingmesh.jobs</groupId>
 			<artifactId>Jobs</artifactId>
-			<version>1.0</version>
-			<systemPath>${basedir}/lib/Jobs.jar</systemPath>
-			<scope>system</scope>
+			<version>4.9.1</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds voting plugin support -->
 		<dependency>
 			<groupId>com.github.Ben12345rocks</groupId>
 			<artifactId>VotingPlugin</artifactId>
-			<version>5.19</version>
+			<version>LATEST</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -125,8 +148,7 @@
 			<groupId>pgDev.bukkit</groupId>
 			<artifactId>CommandPoints</artifactId>
 			<version>1.0</version>
-			<systemPath>${basedir}/lib/CommandPoints.jar</systemPath>
-			<scope>system</scope>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds token manager support -->
@@ -142,71 +164,65 @@
 			<groupId>com.masterderpydoge.tokens</groupId>
 			<artifactId>TokenCore</artifactId>
 			<version>1.4</version>
-			<systemPath>${basedir}/lib/Tokens.jar</systemPath>
-			<scope>system</scope>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds enjin support -->
 		<dependency>
 			<groupId>com.enjin</groupId>
 			<artifactId>EnjinMinecraftPlugin</artifactId>
-			<version>3.5.6</version>
-			<systemPath>${basedir}/lib/EnjinMinecraftPlugin.jar</systemPath>
-			<scope>system</scope>
+			<version>3.5.7</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds points api support -->
 		<dependency>
 			<groupId>me.BukkitPVP</groupId>
 			<artifactId>PointsAPI</artifactId>
-			<version>1.5.1</version>
-			<systemPath>${basedir}/lib/PointsAPI.jar</systemPath>
-			<scope>system</scope>
+			<version>1.6.8</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds token enchant support -->
 		<dependency>
 			<groupId>com.vk2gpz.tokenenchant</groupId>
 			<artifactId>TokenEnchantAPI</artifactId>
-			<version>8.0.0</version>
-			<systemPath>${basedir}/lib/TokenEnchantAPI.jar</systemPath>
-			<scope>system</scope>
+			<version>15.3.2</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds coins support -->
 		<dependency>
 			<groupId>me.justeli.coins.main</groupId>
 			<artifactId>Coins</artifactId>
-			<version>1.4</version>
-			<systemPath>${basedir}/lib/Coins.jar</systemPath>
-			<scope>system</scope>
+			<version>1.9.2</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds gadgets menu support -->
 		<dependency>
 			<groupId>com.yapzhenyie.GadgetsMenu</groupId>
 			<artifactId>GadgetsMenu</artifactId>
-			<version>4.3.20</version>
-			<systemPath>${basedir}/lib/GadgetsMenu.jar</systemPath>
-			<scope>system</scope>
+			<version>4.3.32</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds kingdoms support -->
+		<!-- Provided stubs
 		<dependency>
 			<groupId>org.kingdoms.main</groupId>
 			<artifactId>Kingdoms</artifactId>
 			<version>8.5.3</version>
 			<systemPath>${basedir}/lib/Kingdoms.jar</systemPath>
 			<scope>system</scope>
-		</dependency>
+		</dependency>-->
 
 		<!-- Adds mysql tokens support -->
 		<dependency>
 			<groupId>me.bukkit.mTokens.Inkzzz</groupId>
 			<artifactId>Tokens</artifactId>
-			<version>1.0</version>
-			<systemPath>${basedir}/lib/MySQLTokens.jar</systemPath>
-			<scope>system</scope>
+			<version>1.2</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds silk spawners support -->
@@ -214,18 +230,18 @@
 			<groupId>de.dustplanet.silkspawners.SilkSpawners</groupId>
 			<artifactId>SilkSpawners</artifactId>
 			<version>5.0.2</version>
-			<systemPath>${basedir}/lib/SilkSpawners.jar</systemPath>
-			<scope>system</scope>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Adds epic spawners support -->
+		<!-- Provided stubs
 		<dependency>
 			<groupId>com.songoda.epicspawners</groupId>
 			<artifactId>EpicSpawners</artifactId>
 			<version>6</version>
 			<systemPath>${basedir}/lib/EpicSpawners.jar</systemPath>
 			<scope>system</scope>
-		</dependency>
+		</dependency>-->
 
 		<!-- Used for language utils -->
 		<dependency>

--- a/src/main/java/com/songoda/epicspawners/API/EpicSpawners.java
+++ b/src/main/java/com/songoda/epicspawners/API/EpicSpawners.java
@@ -1,0 +1,28 @@
+package com.songoda.epicspawners.API;
+
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
+public class EpicSpawners {
+
+    public int getSpawnerMultiplier(Location location) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ItemStack newSpawnerItem(EntityType type, int amount) {
+        throw new UnsupportedOperationException();
+    }
+
+    public EntityType getType(ItemStack stack) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static EpicSpawners getInstance() {
+        throw new UnsupportedOperationException();
+    }
+
+    public EpicSpawnersManager getSpawnerManager() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/songoda/epicspawners/API/EpicSpawnersData.java
+++ b/src/main/java/com/songoda/epicspawners/API/EpicSpawnersData.java
@@ -1,0 +1,13 @@
+package com.songoda.epicspawners.API;
+
+import org.bukkit.inventory.ItemStack;
+
+public class EpicSpawnersData {
+    public ItemStack toItemStack() {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getIdentifyingName() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/songoda/epicspawners/API/EpicSpawnersManager.java
+++ b/src/main/java/com/songoda/epicspawners/API/EpicSpawnersManager.java
@@ -1,0 +1,14 @@
+package com.songoda.epicspawners.API;
+
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+
+public class EpicSpawnersManager {
+    public EpicSpawnersData getSpawnerData(String entityType) {
+        throw new UnsupportedOperationException();
+    }
+
+    public EpicSpawnersData getSpawnerData(ItemStack i) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/black_ixx/bossshop/managers/external/spawners/SpawnersHandlerEpicSpawners.java
+++ b/src/main/java/org/black_ixx/bossshop/managers/external/spawners/SpawnersHandlerEpicSpawners.java
@@ -1,7 +1,7 @@
 package org.black_ixx.bossshop.managers.external.spawners;
 
 
-import com.songoda.epicspawners.EpicSpawners;
+import com.songoda.epicspawners.API.EpicSpawners;
 import org.bukkit.inventory.ItemStack;
 
 

--- a/src/main/java/org/black_ixx/bossshop/pointsystem/BSPointsPluginCoins.java
+++ b/src/main/java/org/black_ixx/bossshop/pointsystem/BSPointsPluginCoins.java
@@ -1,6 +1,6 @@
 package org.black_ixx.bossshop.pointsystem;
 
-import me.justeli.coins.main.Coins;
+import me.justeli.coins.Coins;
 import net.milkbowl.vault.economy.EconomyResponse;
 import org.bukkit.OfflinePlayer;
 
@@ -12,29 +12,29 @@ public class BSPointsPluginCoins extends BSPointsPlugin {
 
     @Override
     public double getPoints(OfflinePlayer player) {
-        return Coins.getEcononomy().getBalance(player.getName());
+        return Coins.getEconomy().getBalance(player.getName());
     }
 
     @Override
     public double setPoints(OfflinePlayer player, double points) {
-        double current = Coins.getEcononomy().getBalance(player.getName());
+        double current = Coins.getEconomy().getBalance(player.getName());
         if (current > points) {
-            Coins.getEcononomy().withdrawPlayer(player.getName(), current - points);
+            Coins.getEconomy().withdrawPlayer(player.getName(), current - points);
         } else {
-            Coins.getEcononomy().depositPlayer(player.getName(), points - current);
+            Coins.getEconomy().depositPlayer(player.getName(), points - current);
         }
         return points;
     }
 
     @Override
     public double takePoints(OfflinePlayer player, double points) {
-        EconomyResponse response = Coins.getEcononomy().withdrawPlayer(player.getName(), points);
+        EconomyResponse response = Coins.getEconomy().withdrawPlayer(player.getName(), points);
         return response.balance;
     }
 
     @Override
     public double givePoints(OfflinePlayer player, double points) {
-        EconomyResponse response = Coins.getEcononomy().depositPlayer(player.getName(), points);
+        EconomyResponse response = Coins.getEconomy().depositPlayer(player.getName(), points);
         return response.balance;
     }
 

--- a/src/main/java/org/kingdoms/constants/kingdom/Kingdom.java
+++ b/src/main/java/org/kingdoms/constants/kingdom/Kingdom.java
@@ -1,0 +1,11 @@
+package org.kingdoms.constants.kingdom;
+
+public class Kingdom {
+    public int getResourcepoints() {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setResourcepoints(int points) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/kingdoms/constants/player/OfflineKingdomPlayer.java
+++ b/src/main/java/org/kingdoms/constants/player/OfflineKingdomPlayer.java
@@ -1,0 +1,7 @@
+package org.kingdoms.constants.player;
+
+public class OfflineKingdomPlayer {
+    public String getKingdomName() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/kingdoms/manager/game/GameManagement.java
+++ b/src/main/java/org/kingdoms/manager/game/GameManagement.java
@@ -1,0 +1,11 @@
+package org.kingdoms.manager.game;
+
+public class GameManagement {
+    public static PlayerManager getPlayerManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static KingdomManager getKingdomManager() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/kingdoms/manager/game/KingdomManager.java
+++ b/src/main/java/org/kingdoms/manager/game/KingdomManager.java
@@ -1,0 +1,9 @@
+package org.kingdoms.manager.game;
+
+import org.kingdoms.constants.kingdom.Kingdom;
+
+public class KingdomManager {
+    public Kingdom getOrLoadKingdom(String kingdomName) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/kingdoms/manager/game/PlayerManager.java
+++ b/src/main/java/org/kingdoms/manager/game/PlayerManager.java
@@ -1,0 +1,10 @@
+package org.kingdoms.manager.game;
+
+import org.bukkit.OfflinePlayer;
+import org.kingdoms.constants.player.OfflineKingdomPlayer;
+
+public class PlayerManager {
+    public OfflineKingdomPlayer getOfflineKingdomPlayer(OfflinePlayer player) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Presently BossShopPro has lots of dependencies that are locally provided. This makes it hard to compile.

I've made the following changes:
  * Updated Lombok
  * Change all system deps to provided
  * All missing deps that do not have their own maven repo is provided by repo.worldguard.com.au (mine) now
  * Stub EpicSpawners and Kingdom as it has no public api jar available

This now means anyone can pull the repo and do a 'mvn clean install'.
