### PR TITLE
Update BSShops.java

### DIFF
--- a/src/main/java/org/black_ixx/bossshop/core/BSShops.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSShops.java
@@ -195,6 +195,8 @@ public class BSShops {
     ////////////////////////////////////////////////////////////////////////////
 
     public void refreshShops(boolean mode_serverpinging) {
+    	Bukkit.getScheduler().runTask(ClassManager.manager.getPlugin(), () -> {
+    		
         for (Player p : Bukkit.getOnlinePlayers()) { //If players have a customizable inventory open it needs an update
             if (ClassManager.manager.getPlugin().getAPI().isValidShop(p.getOpenInventory())) {
                 Inventory open_inventory = p.getOpenInventory().getTopInventory();
@@ -212,6 +214,7 @@ public class BSShops {
                 }
             }
         }
+    	});
     }
 
 }

--- a/src/main/java/org/black_ixx/bossshop/core/BSShops.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSShops.java
@@ -194,7 +194,7 @@ public class BSShops {
 
     ////////////////////////////////////////////////////////////////////////////
 
-    public void refreshShops(boolean mode_serverpinging) {
+    public void refreshShops(final boolean mode_serverpinging) {
     	Bukkit.getScheduler().runTask(ClassManager.manager.getPlugin(), () -> {
     		
         for (Player p : Bukkit.getOnlinePlayers()) { //If players have a customizable inventory open it needs an update


### PR DESCRIPTION
Returns scheduled task thread to main thread. Fixes "unable to read block state" error where inventories were being accessed asynchronously. Not sure whether this change will have a noticable impact on performance however.